### PR TITLE
Factory cache

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -93,6 +93,7 @@
   }
   Lisplate.Runtime = runtime;
   Lisplate.Utils = utils;
+  Lisplate.FactoryCache = {};
 
   Lisplate.prototype.addHelper = function addHelper(helperName, fn) {
     this.helpers[helperName] = fn;
@@ -114,11 +115,11 @@
 
     if (renderFactory) {
       renderFactory = Promise.resolve(renderFactory);
+    } else if (_self.cacheEnabled && _self.cache[templateName]) {
+      return Promise.resolve(_self.cache[templateName]);
+    } else if (_self.cacheEnabled && Lisplate.FactoryCache[templateName]) {
+      renderFactory = Promise.resolve(Lisplate.FactoryCache[templateName]);
     } else {
-      if (_self.cache[templateName]) {
-        return Promise.resolve(_self.cache[templateName]);
-      }
-
       if (!_self.sourceLoader) {
         return Promise.reject(new Error('Must define a sourceLoader'));
       }
@@ -145,6 +146,10 @@
     }
 
     return renderFactory.then(function(factory) {
+      if (_self.cacheEnabled) {
+        Lisplate.FactoryCache[templateName] = factory;
+      }
+
       var promise = null;
       if (_self.viewModelLoader) {
         promise = _promisifyPossibleAsync(_self.viewModelLoader)(templateName);
@@ -155,7 +160,10 @@
       return promise.then(function(viewModelClass) {
         var fn = factory(_self, viewModelClass);
         fn.templateName = templateName;
-        _self.cache[templateName] = fn;
+
+        if (_self.cacheEnabled) {
+          _self.cache[templateName] = fn;
+        }
         return fn;
       });
     });


### PR DESCRIPTION
Adding ability to cache factory functions across all Lisplate instances. Finished the forgotten cacheEnable to allow users to disable cache per-instance. The cache-enabled flag also affects the factory-cache.